### PR TITLE
Fix getSessionKey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,8 +98,6 @@ Lastfm.prototype.getSessionKey = function(callback) {
 			try {
 				var parser = new xml2js.Parser();
 				parser.parseString(body, function(err, result) {
-					console.log(result);
-
 					var ret = {
 						success: result['lfm']['$'].status == 'ok'
 					};


### PR DESCRIPTION
The format that LastFM was returning did not appear to be handled correctly, so I went ahead and inspected the format and modified `index.js` to reflect where the keys were.
