### PR TITLE
fix xml2js objects by forcing original working version 0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ var Lastfm = function(options) {
 						body += chunk;
 					});
 					res.on('end', function() {
-						var parser = new xml2js.Parser();
+						var parser = new xml2js.Parser(xml2js.defaults["0.1"]);
 						parser.parseString(body, function(err, result) {
 							if (typeof opt.callback == 'function') {
 								opt.callback(result);
@@ -96,7 +96,7 @@ Lastfm.prototype.getSessionKey = function(callback) {
 		});
 		res.on('end', function() {
 			try {
-				var parser = new xml2js.Parser();
+				var parser = new xml2js.Parser(xml2js.defaults["0.1"]);
 				parser.parseString(body, function(err, result) {
 					var ret = {
 						success: result['@'].status == 'ok'
@@ -202,7 +202,7 @@ Lastfm.prototype.doScrobble = function(options) {
 		res.setEncoding('utf8');
 		res.on('data', function(chunk) {
 //			console.log('Response: ' + chunk);
-			var parser = new xml2js.Parser();
+			var parser = new xml2js.Parser(xml2js.defaults["0.1"]);
 			parser.parseString(chunk, function(err, result) {
 				try {
 					if (result['@'].status == 'ok') {
@@ -369,7 +369,7 @@ Lastfm.prototype.getTracks = function(opt) {
 			body += chunk;
 		});
 		res.on('end', function() {
-			var parser = new xml2js.Parser();
+			var parser = new xml2js.Parser(xml2js.defaults["0.1"]);
 			parser.parseString(body, function(err, result) {
 				if (typeof opt.callback == 'function') {
 					opt.callback(result);


### PR DESCRIPTION
Forced xml2js version 0.1 since v0.2 structure seem to break cmbot's calls to lastfm with: s/xml2js.Parser()/xml2js.Parser(xml2js.defaults["0.1"])/g
